### PR TITLE
Put yamerl in the application dependency list

### DIFF
--- a/src/uaparserl.app.src
+++ b/src/uaparserl.app.src
@@ -2,7 +2,7 @@
              [{description,"Erlang UserAgent parser library"},
               {vsn,"0.1.0"},
               {registered,[]},
-              {applications,[kernel,stdlib]},
+              {applications,[kernel,stdlib,yamerl]},
               {licenses,["MIT"]},
               {links,[{"GitHub","https://github.com/"}]},
               {env,[]}]}.


### PR DESCRIPTION
When an application is depending on another application it is handy to put it in the .app.src file.

Then the vm gives warnings when `yamerl` is not started

```erlang
1> application:start(uaparserl).
{error,{not_started,yamerl}}
2> application:start(yamerl).  
```